### PR TITLE
Update LICENSE from opentradfri to pytradfri

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 opentradfri
+Copyright (c) 2017 pytradfri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As this is now known as pytradfri, the name in the license should be changed accordingly.